### PR TITLE
created a base template for the email

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PROD_COMPOSE := docker compose -f docker-compose.prod.yaml
 # ---------------------------------
 # Development: run container with live-reload
 up:
-	docker compose up
+	docker compose up --build
 
 down:
 	docker compose down
@@ -69,7 +69,7 @@ clean:
 # ---------------------------------
 help:
 	@echo "Available make commands:"
-	@echo "  make up          - Run the api application with Docker Compose"
+	@echo "  make up          - Build and run the API with Docker Compose"
 	@echo "  make down        - Stop the Docker Compose services"
 	@echo "  make deploy      - Down, pull, and start the production image"
 	@echo "  make prod-down   - Stop the production Compose services"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ make upgrade
 docker compose up
 ```
 
+The development Compose configuration rebuilds the API image when it starts, so
+new dependencies from `pyproject.toml` and `uv.lock` are installed automatically.
+The equivalent Make command is `make up`.
+
 The development Compose stack includes PostgreSQL 18 with a persistent
 `postgres_data` volume. The `.env` `DATABASE_URL` uses `localhost`, allowing
 host-side Alembic commands such as `make upgrade` to connect to it. Inside
@@ -131,7 +135,15 @@ make deploy
 
 The deployment command stops the existing production stack, pulls the image,
 and starts it in detached mode using `docker-compose.prod.yaml`. Production does
-not mount source files and does not enable Uvicorn reload.
+not mount source files and does not enable Uvicorn reload. The container still
+listens on port 8000 internally, but production publishes it on
+`127.0.0.1:8001` by default to avoid conflicts with other containers.
+
+To use another host port:
+
+```bash
+API_HOST_PORT=8010 make deploy
+```
 
 Deploy a specific immutable image version with:
 
@@ -146,8 +158,9 @@ GitHub token that has `read:packages` permission:
 docker login ghcr.io
 ```
 
-The API is available at <http://127.0.0.1:8000>, with interactive documentation
-at <http://127.0.0.1:8000/docs>.
+With the default production port, the API is available internally on the host at
+<http://127.0.0.1:8001>, with interactive documentation at
+<http://127.0.0.1:8001/docs>.
 
 The container uses Python 3.14.
 

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -8,4 +8,4 @@ services:
     env_file:
       - .env.prod
     ports:
-      - "127.0.0.1:8000:8000"
+      - "127.0.0.1:${API_HOST_PORT:-8001}:8000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    pull_policy: never
+    # Rebuild the development image when Compose starts so changes to
+    # pyproject.toml or uv.lock are installed in the container.
+    pull_policy: build
     command: uv run uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
     restart: always
     volumes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "email-validator>=2.3.0",
     "fastapi>=0.128.0",
     "httpx>=0.28.1",
+    "jinja2>=3.1.6",
     "psycopg2-binary>=2.9.11",
     "pydantic>=2.12.0",
     "pydantic-core>=2.41.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ fastapi==0.139.2
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
+jinja2==3.1.6
 idna==3.10
 iniconfig==2.1.0
 mako==1.3.10

--- a/src/modules/email/__init__.py
+++ b/src/modules/email/__init__.py
@@ -1,3 +1,4 @@
 from src.modules.email.service import EmailMessage, EmailService
+from src.modules.email.templates import EmailTemplateRenderer
 
-__all__ = ["EmailMessage", "EmailService"]
+__all__ = ["EmailMessage", "EmailService", "EmailTemplateRenderer"]

--- a/src/modules/email/service.py
+++ b/src/modules/email/service.py
@@ -34,7 +34,7 @@ class ResendEmailProvider:
         self.api_key = api_key
 
     def send(self, *, sender: str, receiver: str, message: EmailMessage) -> str:
-        payload = {
+        payload: resend.Emails.SendParams = {
             "from": sender,
             "to": [receiver],
             "subject": message.subject,

--- a/src/modules/email/templates.py
+++ b/src/modules/email/templates.py
@@ -1,0 +1,39 @@
+"""Render reusable HTML email templates.
+
+This module configures Jinja to load templates from the application's ``src``
+directory. It supports shared template inheritance, such as an application email
+extending the general email layout, and automatically escapes values inserted
+into HTML or XML templates.
+"""
+
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+# ``templates.py`` lives in ``src/modules/email``. Moving two parents upward
+# provides ``src`` as the common root for templates owned by any application or
+# shared module.
+TEMPLATE_ROOT = Path(__file__).resolve().parents[2]
+
+
+class EmailTemplateRenderer:
+    """A configured Jinja renderer for application and shared email templates.
+
+    An instance represents the email-template environment: it knows where
+    templates are stored, how inheritance is resolved, and which template types
+    require automatic escaping. A different root can be supplied by tests or by
+    an application that stores its templates elsewhere.
+    """
+
+    def __init__(self, template_root: Path = TEMPLATE_ROOT):
+        """Create a renderer that loads templates beneath ``template_root``."""
+        self.environment = Environment(
+            loader=FileSystemLoader(template_root),
+            autoescape=select_autoescape(("html", "xml")),
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+
+    def render(self, template_name: str, **context: object) -> str:
+        """Render ``template_name`` with the provided context values."""
+        return self.environment.get_template(template_name).render(**context)

--- a/src/modules/email/templates/base.html
+++ b/src/modules/email/templates/base.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Notification{% endblock %}</title>
+</head>
+<body style="margin:0; padding:0; background-color:#f4f6f8; color:#263238; font-family:{% block font_family %}Arial, Helvetica, sans-serif{% endblock %}; font-size:16px; line-height:1.6;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background-color:#f4f6f8;">
+    <tr>
+      <td align="center" style="padding:32px 16px;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:680px; background:#ffffff; border-radius:10px; border:1px solid #e3e8ec;">
+          <tr>
+            <td style="padding:32px;">
+              {% block content %}
+              <h2 style="margin:0 0 16px; color:#183b56; font-size:26px; line-height:1.3;">{{ heading }}</h2>
+              <p style="margin:0; font-size:16px;">{{ message }}</p>
+              {% endblock %}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:18px 32px; background:#f8fafb; border-top:1px solid #e3e8ec; color:#607d8b; font-size:13px;">
+              {% block footer %}This is an automated notification.{% endblock %}
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/modules/forms/service.py
+++ b/src/modules/forms/service.py
@@ -10,14 +10,16 @@ from sqlalchemy.orm import Session
 from src.modules.forms.models import ZaansrechtForm, FormSubmissionLog
 from src.enums import FormStatus
 from src.modules.email.service import EmailMessage, EmailService
+from src.modules.email.templates import EmailTemplateRenderer
 import logging
 
 logger = logging.getLogger(__name__)
 
 
 class FormService:
-    def __init__(self, db: Session):
+    def __init__(self, db: Session, template_renderer: EmailTemplateRenderer | None = None):
         self.db = db
+        self.template_renderer = template_renderer or EmailTemplateRenderer()
 
     def create_zaansrecht_form(
             self,
@@ -76,19 +78,34 @@ class FormService:
         """Send a notification email upon form submission."""
         email_service = EmailService(self.db)
         subject = f"New Zaansrecht form submission: {form.subject or 'No subject'}"
-        body = (
-            "A new Zaansrecht form has been submitted.\n\n"
-            f"Name: {form.full_name}\n"
-            f"Email: {form.email}\n"
-            f"Telephone: {form.telephone or '-'}\n"
-            f"Description: {form.description or '-'}\n"
+        meeting_datetime = (
+            form.meeting_datetime.strftime("%d-%m-%Y %H:%M")
+            if form.meeting_datetime
+            else "Niet opgegeven"
         )
+        fields = (
+            {"label": "Naam", "value": form.full_name},
+            {"label": "E-mailadres", "value": form.email},
+            {"label": "Telefoon", "value": form.telephone or "Niet opgegeven"},
+            {"label": "Onderwerp", "value": form.subject or "Niet opgegeven"},
+            {"label": "Beschrijving", "value": form.description or "Niet opgegeven"},
+            {"label": "Afspraak", "value": meeting_datetime},
+            {"label": "Type afspraak", "value": form.meeting_type or "Niet opgegeven"},
+            {"label": "Voorwaarden geaccepteerd", "value": "Ja" if form.terms_accepted else "Nee"},
+        )
+        html = self.template_renderer.render(
+            "modules/forms/templates/zaansrecht_email.html",
+            fields=fields,
+            email=str(form.email),
+        )
+        text = "\n".join(f"{field['label']}: {field['value']}" for field in fields)
 
         log = email_service.send(EmailMessage(
             application="zaansrecht",
             reply_to=str(form.email),
             subject=subject,
-            text=body,
+            text=text,
+            html=html,
         ))
         logger.info("Processed notification email %d for form %d", log.id, form.id)
         return log

--- a/src/modules/forms/templates/zaansrecht_email.html
+++ b/src/modules/forms/templates/zaansrecht_email.html
@@ -1,0 +1,20 @@
+{% extends "modules/email/templates/base.html" %}
+
+{% block title %}Nieuwe Zaansrecht inzending{% endblock %}
+{% block font_family %}Verdana, Geneva, sans-serif{% endblock %}
+
+{% block content %}
+<h2 style="margin:0 0 10px; color:#002b5c; font-size:27px; line-height:1.3;">Nieuwe formulierinzending</h2>
+<p style="margin:0 0 24px; color:#52616b; font-size:15px;">Er is een nieuw formulier ingediend via Zaansrecht.</p>
+
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="border-collapse:collapse; font-size:15px;">
+  {% for field in fields %}
+  <tr>
+    <td style="width:34%; padding:11px 12px; border-bottom:1px solid #e5e9ed; color:#455a64; font-weight:700; vertical-align:top;">{{ field.label }}</td>
+    <td style="padding:11px 12px; border-bottom:1px solid #e5e9ed; color:#1f2933; vertical-align:top; white-space:pre-wrap; overflow-wrap:anywhere;">{{ field.value }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}
+
+{% block footer %}Zaansrecht · Beantwoord deze e-mail om contact op te nemen met {{ email }}.{% endblock %}

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -1,0 +1,30 @@
+from src.modules.email.templates import EmailTemplateRenderer
+
+
+def test_base_email_template_renders_basic_elements_and_escapes_values() -> None:
+    html = EmailTemplateRenderer().render(
+        "modules/email/templates/base.html",
+        heading="Account update",
+        message="Hello <Admin>",
+    )
+
+    assert "<h2" in html
+    assert "font-family:Arial, Helvetica, sans-serif" in html
+    assert "font-size:16px" in html
+    assert "Account update" in html
+    assert "Hello &lt;Admin&gt;" in html
+
+
+def test_zaansrecht_template_inherits_base_layout_and_overrides_font() -> None:
+    html = EmailTemplateRenderer().render(
+        "modules/forms/templates/zaansrecht_email.html",
+        fields=({"label": "Naam", "value": "Zaansrecht User"},),
+        email="reply@example.com",
+    )
+
+    assert "<!doctype html>" in html
+    assert "This is an automated notification" not in html
+    assert "Verdana, Geneva, sans-serif" in html
+    assert "Nieuwe formulierinzending" in html
+    assert "Zaansrecht User" in html
+    assert "reply@example.com" in html

--- a/tests/test_form_service.py
+++ b/tests/test_form_service.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from src.enums import FormStatus
 from src.modules.forms.models import ZaansrechtForm
 from src.modules.forms.service import FormService, FormSubmissionLogService
@@ -118,11 +120,37 @@ def test_form_notification_uses_general_email_service(monkeypatch) -> None:
     monkeypatch.setattr("src.modules.forms.service.EmailService", FakeEmailService)
     form = ZaansrechtForm(
         id=1,
-        full_name="Test",
+        full_name="Test <script>alert('x')</script>",
         email="reply@example.com",
         terms_accepted=True,
+        telephone="06-12345678",
         subject="Question",
+        description="A clear description",
+        meeting_datetime=datetime(2026, 7, 24, 14, 30),
+        meeting_type="virtual",
     )
     log = FormService(FakeSession()).send_form_notification(form)
     assert log.id == 12
-    assert captured["message"].application == "zaansrecht"
+    message = captured["message"]
+    assert message.application == "zaansrecht"
+    assert message.html is not None
+    assert "Verdana, Geneva, sans-serif" in message.html
+    assert "Test &lt;script&gt;" in message.html
+    assert "<script>alert" not in message.html
+    for expected in (
+        "Naam",
+        "E-mailadres",
+        "Telefoon",
+        "Onderwerp",
+        "Beschrijving",
+        "Afspraak",
+        "Type afspraak",
+        "Voorwaarden geaccepteerd",
+        "24-07-2026 14:30",
+        "06-12345678",
+        "A clear description",
+        "virtual",
+        "Ja",
+    ):
+        assert expected in message.html
+    assert "Naam: Test" in message.text

--- a/uv.lock
+++ b/uv.lock
@@ -276,6 +276,7 @@ dependencies = [
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "jinja2" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-core" },
@@ -302,6 +303,7 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastapi", specifier = ">=0.128.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pydantic-core", specifier = ">=2.41.0" },
@@ -407,6 +409,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Base email html template.
- Zaanstrecht inherits from the base email template.
- Changed the port number of the api on production to avoid conflict with other api.
- Build the container when starting it on dev